### PR TITLE
为自动保存添加导出 html 功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "ha0xin",
   "license": "MIT",
   "description": "导出 ChatGPT 对话 json + 会话中的多模态文件（图片、音频、sandbox 文件等）",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -13,7 +16,9 @@
   },
   "dependencies": {
     "@preact/signals": "^2.5.1",
+    "@types/marked": "^6.0.0",
     "fflate": "^0.8.2",
+    "marked": "^15.0.12",
     "preact": "^10.28.0",
     "sonner": "^2.0.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
       '@preact/signals':
         specifier: ^2.5.1
         version: 2.5.1(preact@10.28.0)
+      '@types/marked':
+        specifier: ^6.0.0
+        version: 6.0.0
       fflate:
         specifier: ^0.8.2
         version: 0.8.2
+      marked:
+        specifier: ^15.0.12
+        version: 15.0.12
       preact:
         specifier: ^10.28.0
         version: 10.28.0
@@ -455,6 +461,10 @@ packages:
   '@types/greasemonkey@4.0.7':
     resolution: {integrity: sha512-DuYBRf/T4zixO/xhQ3eicZCBjjOgbSSXuHP5XkLNf/UBayrJpBniP9il/AQaPy0lffl4Bco48zgHL+pZmQ6Q0A==}
 
+  '@types/marked@6.0.0':
+    resolution: {integrity: sha512-jmjpa4BwUsmhxcfsgUit/7A9KbrC48Q0q8KvnY107ogcjGgTFDlIL3RpihNpx2Mu1hM4mdFQjoVc4O6JoGKHsA==}
+    deprecated: This is a stub types definition. marked provides its own type definitions, so you do not need this installed.
+
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
@@ -644,6 +654,11 @@ packages:
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   mime@2.5.2:
     resolution: {integrity: sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==}
@@ -1192,6 +1207,10 @@ snapshots:
 
   '@types/greasemonkey@4.0.7': {}
 
+  '@types/marked@6.0.0':
+    dependencies:
+      marked: 15.0.12
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.15.0
@@ -1372,6 +1391,8 @@ snapshots:
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
+
+  marked@15.0.12: {}
 
   mime@2.5.2: {}
 

--- a/src/html/messages.ts
+++ b/src/html/messages.ts
@@ -1,0 +1,409 @@
+import { marked } from 'marked';
+
+import { pointerToFileId } from '../utils';
+import { sanitizeHtmlContent } from './sanitize';
+import {
+    escapeHtml,
+    getFaviconUrl,
+    getHostname,
+    getThoughtsText,
+    normalizeListIndentation,
+    stripChatgptUtm
+} from './utils';
+import type {
+    CanvasState,
+    ExportedAttachment,
+    RenderedAttachment,
+    RenderedMessage
+} from './types';
+
+function isImageFile(name: string, mime?: string): boolean {
+    if (mime && mime.startsWith('image/')) return true;
+    return /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(name);
+}
+
+function findExportedAttachment(allAttachments: ExportedAttachment[], key: string): ExportedAttachment | undefined {
+    return allAttachments.find((att) =>
+        att.file_id === key || att.id === key || att.pointer === key
+    );
+}
+
+function collectMessageAttachments(
+    msg: any,
+    allAttachments: ExportedAttachment[],
+    textContent: string,
+    inlineKeys: Set<string>
+): RenderedAttachment[] {
+    const out: RenderedAttachment[] = [];
+    const seen = new Set<string>();
+
+    const addByKey = (key: string, meta?: any) => {
+        const normalized = key ? key.replace('sediment://', '') : '';
+        if (!normalized) return;
+        if (inlineKeys.has(normalized) || inlineKeys.has(key)) return;
+
+        const found = findExportedAttachment(allAttachments, normalized) || findExportedAttachment(allAttachments, key);
+        if (!found) return;
+
+        const name =
+            found.saved_as ||
+            found.name ||
+            found.original_name ||
+            meta?.name ||
+            meta?.file_name ||
+            normalized;
+        if (!name) return;
+
+        const url = `attachments/${name}`;
+        if (inlineKeys.has(url)) return;
+
+        const uniq = `${found.file_id || found.id || found.pointer || normalized}:${name}`;
+        if (seen.has(uniq)) return;
+        seen.add(uniq);
+
+        const mime = found.mime || meta?.mime_type || meta?.mime || '';
+        out.push({
+            url,
+            name,
+            isImage: isImageFile(name, mime)
+        });
+    };
+
+    const meta = msg?.metadata || {};
+    if (Array.isArray(meta.attachments)) {
+        for (const att of meta.attachments) {
+            if (!att?.id) continue;
+            addByKey(att.id, att);
+        }
+    }
+
+    const refsByFile = meta.content_references_by_file || meta.n7jupd_crefs_by_file;
+    if (refsByFile && !Array.isArray(refsByFile) && typeof refsByFile === 'object') {
+        for (const fileId of Object.keys(refsByFile)) {
+            addByKey(fileId);
+        }
+    }
+
+    const refs = Array.isArray(meta.content_references)
+        ? meta.content_references
+        : (Array.isArray(meta.n7jupd_crefs) ? meta.n7jupd_crefs : []);
+    for (const ref of refs) {
+        if (ref?.file_id) addByKey(ref.file_id, ref);
+        if (ref?.asset_pointer) addByKey(pointerToFileId(ref.asset_pointer), ref);
+    }
+
+    const fileTokens = textContent.match(/\{\{file:([^}]+)\}\}/g) || [];
+    for (const tok of fileTokens) {
+        const fid = tok.slice(7, -2);
+        addByKey(fid);
+    }
+
+    const sandboxLinks = textContent.match(/sandbox:[^\s)\]]+/g) || [];
+    for (const link of sandboxLinks) {
+        addByKey(link);
+    }
+
+    return out;
+}
+
+function renderCitationLink(url: string, title: string, index: number): string {
+    const cleanedUrl = stripChatgptUtm(url);
+    return `<a href="${escapeHtml(cleanedUrl)}" target="_blank" title="${escapeHtml(title || '')}" style="color: #10a37f; text-decoration: none; font-size: 0.8em; margin: 0 2px; background: #e0f7fa; padding: 2px 5px; border-radius: 4px;">[${index}]</a>`;
+}
+
+function applyCanvasUpdates(baseContent: string, updates: any[]): string {
+    let updated = baseContent;
+    for (const update of updates) {
+        const pattern = typeof update?.pattern === 'string' ? update.pattern : '';
+        if (!pattern) continue;
+        const replacement = typeof update?.replacement === 'string' ? update.replacement : '';
+        try {
+            const regex = new RegExp(pattern, 'g');
+            updated = updated.replace(regex, replacement);
+        } catch (e) {
+            if (typeof console !== 'undefined' && console.debug) {
+                console.debug('Invalid canvas update pattern', pattern, e);
+            }
+        }
+    }
+    return updated;
+}
+
+function renderCanvasBlock(title: string, content: string): string {
+    return `
+    <div class="canvas-block">
+        <div class="canvas-header">
+            <span>${escapeHtml(title)}</span>
+            <span class="canvas-badge">HTML</span>
+        </div>
+        <div class="canvas-body">
+            ${marked.parse('```html\n' + content + '\n```')}
+        </div>
+    </div>`;
+}
+
+export function getRawMessageText(msg: any, allAttachments: ExportedAttachment[]): string {
+    if (!msg?.content) return '';
+    const contentType = msg.content.content_type;
+    if (contentType === 'thoughts') return getThoughtsText(msg.content);
+    if (contentType === 'reasoning_recap') return String(msg.content.content || '');
+    let textContent = '';
+    if (contentType === 'text' && msg.content.parts) {
+        textContent = msg.content.parts.join('\n');
+    } else if (contentType === 'multimodal_text' && msg.content.parts) {
+        for (const part of msg.content.parts) {
+            if (typeof part === 'string') {
+                textContent += part + '\n';
+            } else if (part.asset_pointer) {
+                const fileId = part.asset_pointer.replace('sediment://', '');
+                const found = allAttachments.find(a => (a.file_id === fileId || a.id === fileId));
+                if (found) {
+                    const filename = found.saved_as || found.name || 'image.png';
+                    const originalName = found.original_name || found.name || 'Image';
+                    const relPath = `attachments/${filename}`;
+                    textContent += `\n![${originalName}](${relPath})\n`;
+                }
+            }
+        }
+    } else if (typeof msg.content.text === 'string') {
+        textContent = msg.content.text;
+    } else if (Array.isArray(msg.content.parts)) {
+        textContent = msg.content.parts.map((part: any) => typeof part === 'string' ? part : '').join('\n');
+    } else if (typeof msg.content.content === 'string') {
+        textContent = msg.content.content;
+    }
+    return textContent;
+}
+
+export function renderMessage(msg: any, allAttachments: ExportedAttachment[], canvasState: CanvasState): RenderedMessage {
+    const role = msg.author.role;
+    let textContent = '';
+    const inlineAttachmentKeys = new Set<string>();
+    const userImageItems: { url: string; name: string }[] = [];
+
+    if (msg.content) {
+        if (msg.content.content_type === 'text' && msg.content.parts) {
+            textContent = msg.content.parts.join('\n');
+        } else if (msg.content.content_type === 'text' && typeof msg.content.text === 'string') {
+            textContent = msg.content.text;
+        } else if (msg.content.content_type === 'multimodal_text' && msg.content.parts) {
+            for (const part of msg.content.parts) {
+                if (typeof part === 'string') {
+                    textContent += part + '\n';
+                } else if (part.asset_pointer) {
+                    const fileId = part.asset_pointer.replace('sediment://', '');
+                    const found = allAttachments.find(a => (a.file_id === fileId || a.id === fileId));
+                    if (found) {
+                        const filename = found.saved_as || found.name || 'image.png';
+                        const originalName = found.original_name || found.name || 'Image';
+                        const relPath = `attachments/${filename}`;
+                        inlineAttachmentKeys.add(fileId);
+                        inlineAttachmentKeys.add(relPath);
+                        if (role === 'user') {
+                            userImageItems.push({ url: relPath, name: originalName });
+                        } else {
+                            textContent += `\n![${escapeHtml(originalName)}](${relPath})\n`;
+                        }
+                    }
+                }
+            }
+            if (role === 'user' && userImageItems.length > 0) {
+                const carouselItems = userImageItems.map((img) =>
+                    `<div class="image-card"><img src="${escapeHtml(img.url)}" alt="${escapeHtml(img.name)}" loading="lazy" /></div>`
+                ).join('');
+                const carouselHtml = `\n<div class="image-carousel user-images">${carouselItems}</div>\n`;
+                textContent += carouselHtml;
+            }
+        }
+    }
+
+    const attachments = collectMessageAttachments(msg, allAttachments, textContent, inlineAttachmentKeys);
+
+    if (msg.metadata?.content_references) {
+        const refs = [...msg.metadata.content_references].sort((a: any, b: any) => b.start_idx - a.start_idx);
+
+        for (const ref of refs) {
+            if (ref.type === 'image_group' && ref.images) {
+                const carouselItems = ref.images.map((img: any) => {
+                    const imgUrl = img.image_result?.content_url || img.image_result?.url;
+                    if (!imgUrl) return '';
+                    const pageUrl = stripChatgptUtm(img.image_result?.url || '');
+                    const title = img.image_result?.title || (pageUrl ? getHostname(pageUrl) : 'Image');
+                    const favicon = pageUrl ? getFaviconUrl(pageUrl) : '';
+                    const sourceHtml = pageUrl ? `<a class="image-source" href="${escapeHtml(pageUrl)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(title)}">
+                            ${favicon ? `<img src="${escapeHtml(favicon)}" alt="" aria-hidden="true" onerror="this.style.display='none';" />` : ''}
+                            <span>${escapeHtml(title)}</span>
+                        </a>` : '';
+                    return `<div class="image-card"><img src="${escapeHtml(imgUrl)}" alt="${escapeHtml(title)}" loading="lazy" />${sourceHtml}</div>`;
+                }).join('');
+                const carouselHtml = `\n<div class="image-carousel">${carouselItems}</div>\n`;
+
+                if (textContent.includes(ref.matched_text)) {
+                    textContent = textContent.replace(ref.matched_text, carouselHtml);
+                }
+            }
+
+            if (ref.type === 'webpage' || ref.type === 'webpage_extended') {
+                if (textContent.includes(ref.matched_text)) {
+                    const index = msg.metadata.content_references.indexOf(ref) + 1;
+                    const url = stripChatgptUtm(ref.url || '');
+                    if (url) {
+                        const citationHtml = renderCitationLink(url, ref.title || '', index);
+                        textContent = textContent.replace(ref.matched_text, citationHtml);
+                    } else {
+                        textContent = textContent.replace(ref.matched_text, '');
+                    }
+                }
+            }
+
+            if (ref.type === 'grouped_webpages') {
+                if (textContent.includes(ref.matched_text)) {
+                    const items = Array.isArray(ref.items) ? ref.items : [];
+                    const url = stripChatgptUtm(items[0]?.url || ref.safe_urls?.[0] || '');
+                    const title = items[0]?.title || ref.alt || url;
+                    const index = msg.metadata.content_references.indexOf(ref) + 1;
+                    if (url) {
+                        const citationHtml = renderCitationLink(url, title || '', index);
+                        textContent = textContent.replace(ref.matched_text, citationHtml);
+                    } else {
+                        textContent = textContent.replace(ref.matched_text, '');
+                    }
+                }
+            }
+
+            if (ref.type === 'file') {
+                if (textContent.includes(ref.matched_text)) {
+                    const fileHtml = `<span title="${escapeHtml(ref.name || 'File')}" style="color: #555; font-size: 0.8em; margin: 0 2px; background: #f0f0f0; padding: 2px 5px; border-radius: 4px; border: 1px solid #ddd;">[File: ${escapeHtml(ref.name || 'Attachment')}]</span>`;
+                    textContent = textContent.replace(ref.matched_text, fileHtml);
+                }
+            }
+        }
+    }
+
+    if (role === 'tool' && msg.content?.content_type === 'multimodal_text') {
+        const parts = msg.content.parts || [];
+        for (const part of parts) {
+            if (part.asset_pointer) {
+                const fileId = part.asset_pointer.replace('sediment://', '');
+                const found = allAttachments.find(a => (a.file_id === fileId || a.id === fileId));
+                if (found) {
+                    const filename = found.saved_as || found.name || 'image.png';
+                    const originalName = found.original_name || found.name || 'Generated Image';
+                    const relPath = `attachments/${filename}`;
+                    return {
+                        role: 'assistant',
+                        htmlContent: `<div style="text-align:center; margin: 20px 0;"><img src="${relPath}" alt="${escapeHtml(originalName)}" style="max-width: 100%; border-radius: 12px; box-shadow: 0 4px 12px rgba(0,0,0,0.1);" /></div>`,
+                        modelSlug: msg.metadata?.model_slug,
+                        attachments
+                    };
+                }
+            }
+        }
+    }
+
+    if (role === 'assistant' && textContent.trim().startsWith('{') && textContent.includes('"referenced_image_ids":')) {
+        try {
+            const json = JSON.parse(textContent);
+            if (json.prompt) {
+                const promptHtml = `<div style="font-size: 0.9em; color: #666; font-style: italic;">
+                    Generative Prompt: "${escapeHtml(json.prompt)}"
+                </div>`;
+                return {
+                    role: 'assistant',
+                    htmlContent: promptHtml,
+                    modelSlug: msg.metadata?.model_slug,
+                    attachments
+                };
+            }
+        } catch (e) {
+        }
+    }
+
+    if (msg.content?.content_type === 'thoughts') {
+        const thoughts = getThoughtsText(msg.content);
+        const html = `
+        <details style="margin-bottom: 10px; border: 1px solid #ddd; border-radius: 8px; padding: 10px;">
+            <summary style="cursor: pointer; font-weight: bold; color: #666;">Reasoning Process</summary>
+            <div style="margin-top: 10px; color: #444; white-space: pre-wrap; font-family: monospace; font-size: 0.9em;">${escapeHtml(thoughts)}</div>
+        </details>`;
+        return {
+            role,
+            htmlContent: html,
+            modelSlug: msg.metadata?.model_slug,
+            attachments
+        };
+    }
+
+    if (msg.content?.content_type === 'reasoning_recap') {
+        return {
+            role,
+            htmlContent: `<div style="font-size: 0.85em; color: #888; margin-bottom: 5px;">${escapeHtml(msg.content.content || '')}</div>`,
+            modelSlug: msg.metadata?.model_slug,
+            attachments
+        };
+    }
+
+    if (role === 'assistant' && textContent.trim().startsWith('{')) {
+        try {
+            const json = JSON.parse(textContent);
+            if (json.name && json.type === 'code/html' && json.content) {
+                const name = String(json.name);
+                const content = String(json.content);
+                canvasState.byName[name] = content;
+                canvasState.lastName = name;
+                canvasState.lastContent = content;
+                const canvasHtml = renderCanvasBlock(`Canvas: ${name}`, content);
+                return {
+                    role,
+                    htmlContent: canvasHtml,
+                    modelSlug: msg.metadata?.model_slug,
+                    attachments
+                };
+            }
+            if (json.updates && Array.isArray(json.updates)) {
+                const baseName = canvasState.lastName;
+                const baseContent = baseName ? canvasState.byName[baseName] : canvasState.lastContent;
+                if (baseContent) {
+                    const updatedContent = applyCanvasUpdates(baseContent, json.updates);
+                    if (baseName) {
+                        canvasState.byName[baseName] = updatedContent;
+                    }
+                    canvasState.lastContent = updatedContent;
+                    const title = baseName ? `Canvas Updated: ${baseName}` : 'Canvas Updated';
+                    return {
+                        role,
+                        htmlContent: renderCanvasBlock(title, updatedContent),
+                        modelSlug: msg.metadata?.model_slug,
+                        attachments
+                    };
+                }
+                const updatesHtml = `
+                 <div class="canvas-update-block" style="border: 1px solid #e0e0e0; border-radius: 8px; margin: 10px 0; background: #fafafa;">
+                    <div style="padding: 8px 12px; color: #666; font-size: 0.9em;">
+                        <strong>Canvas Updated</strong>
+                    </div>
+                    <div style="padding: 10px; font-family: monospace; font-size: 0.85em; overflow-x: auto;">
+                        ${json.updates.map((u: any) => `<div><span style="color: #d32f2f;">- ${escapeHtml(u.pattern || '')}</span><br><span style="color: #388e3c;">+ ${escapeHtml(u.replacement || '')}</span></div>`).join('<hr style="margin: 5px 0; border: 0; border-top: 1px dashed #ccc;">')}
+                    </div>
+                 </div>`;
+                return {
+                    role,
+                    htmlContent: updatesHtml,
+                    modelSlug: msg.metadata?.model_slug,
+                    attachments
+                };
+            }
+        } catch (e) {
+        }
+    }
+
+    const rawHtml = marked.parse(normalizeListIndentation(textContent), { async: false }) as string;
+    const htmlContent = sanitizeHtmlContent(rawHtml);
+
+    return {
+        role,
+        htmlContent,
+        modelSlug: msg.metadata?.model_slug,
+        attachments
+    };
+}

--- a/src/html/sanitize.ts
+++ b/src/html/sanitize.ts
@@ -1,0 +1,106 @@
+const ALLOWED_HTML_TAGS = new Set([
+    'a', 'abbr', 'b', 'blockquote', 'br', 'code', 'del', 'details', 'div', 'em',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'li', 'ol', 'p', 'pre',
+    'span', 'strong', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'th',
+    'thead', 'tr', 'u', 'ul'
+]);
+const DROP_HTML_TAGS = new Set(['script', 'style', 'iframe', 'object', 'embed', 'link', 'meta', 'base']);
+const GLOBAL_ALLOWED_ATTRS = new Set(['class', 'title', 'style', 'role']);
+const TAG_ALLOWED_ATTRS: Record<string, Set<string>> = {
+    a: new Set(['href', 'target', 'rel']),
+    img: new Set(['src', 'alt', 'loading']),
+    th: new Set(['colspan', 'rowspan', 'align', 'scope']),
+    td: new Set(['colspan', 'rowspan', 'align'])
+};
+const SAFE_DATA_IMAGE_PATTERN = /^data:image\/(png|jpe?g|gif|webp);base64,/i;
+
+function isSafeUrl(url: string, tagName: string): boolean {
+    const trimmed = (url || '').trim();
+    if (!trimmed) return true;
+    const lower = trimmed.toLowerCase();
+    if (lower.startsWith('javascript:') || lower.startsWith('vbscript:')) return false;
+    if (lower.startsWith('data:')) {
+        return tagName === 'img' && SAFE_DATA_IMAGE_PATTERN.test(lower);
+    }
+    if (
+        lower.startsWith('http:') ||
+        lower.startsWith('https:') ||
+        lower.startsWith('mailto:') ||
+        lower.startsWith('tel:') ||
+        lower.startsWith('sandbox:') ||
+        lower.startsWith('//')
+    ) {
+        return true;
+    }
+    return !/^[a-z][a-z0-9+.-]*:/.test(lower);
+}
+
+function isSafeStyle(style: string): boolean {
+    const lower = (style || '').toLowerCase();
+    if (lower.includes('expression(')) return false;
+    if (lower.includes('javascript:')) return false;
+    if (/url\(\s*['"]?\s*javascript:/i.test(lower)) return false;
+    if (/url\(\s*['"]?\s*data:text\/html/i.test(lower)) return false;
+    return true;
+}
+
+function isAllowedAttr(tagName: string, attrName: string): boolean {
+    if (attrName.startsWith('data-')) return true;
+    if (attrName.startsWith('aria-')) return true;
+    if (GLOBAL_ALLOWED_ATTRS.has(attrName)) return true;
+    const tagAllowed = TAG_ALLOWED_ATTRS[tagName];
+    return Boolean(tagAllowed && tagAllowed.has(attrName));
+}
+
+function sanitizeElementAttributes(el: Element, tagName: string) {
+    for (const attr of Array.from(el.attributes)) {
+        const name = attr.name.toLowerCase();
+        if (!isAllowedAttr(tagName, name)) {
+            el.removeAttribute(attr.name);
+            continue;
+        }
+        if ((name === 'href' || name === 'src') && !isSafeUrl(attr.value, tagName)) {
+            el.removeAttribute(attr.name);
+            continue;
+        }
+        if (name === 'style' && !isSafeStyle(attr.value)) {
+            el.removeAttribute(attr.name);
+        }
+    }
+
+    if (tagName === 'a' && el.getAttribute('target') === '_blank') {
+        const rel = (el.getAttribute('rel') || '').split(/\s+/).filter(Boolean);
+        if (!rel.includes('noopener')) rel.push('noopener');
+        if (!rel.includes('noreferrer')) rel.push('noreferrer');
+        el.setAttribute('rel', rel.join(' '));
+    }
+}
+
+export function sanitizeHtmlContent(html: string): string {
+    if (!html) return html;
+    if (typeof DOMParser === 'undefined') return html;
+
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const elements = Array.from(doc.body.querySelectorAll('*'));
+
+    for (const el of elements) {
+        if (!el.parentNode) continue;
+        const tagName = el.tagName.toLowerCase();
+        if (!ALLOWED_HTML_TAGS.has(tagName)) {
+            if (DROP_HTML_TAGS.has(tagName)) {
+                el.remove();
+                continue;
+            }
+            const parent = el.parentNode;
+            if (!parent) continue;
+            while (el.firstChild) {
+                parent.insertBefore(el.firstChild, el);
+            }
+            parent.removeChild(el);
+            continue;
+        }
+        sanitizeElementAttributes(el, tagName);
+    }
+
+    return doc.body.innerHTML;
+}

--- a/src/html/template.ts
+++ b/src/html/template.ts
@@ -1,0 +1,689 @@
+import { escapeHtml, escapeHtmlAttr } from './utils';
+import { VIRTUAL_ROOT_ID } from './tree';
+import type { RenderedAttachment, RenderedNode } from './types';
+
+function renderAttachments(atts: RenderedAttachment[]): string {
+    if (atts.length === 0) return '';
+    return `<div class="attachments">
+        ${atts.map(a => {
+        if (a.isImage) {
+            return `<img src="${a.url}" alt="${escapeHtml(a.name)}" />`;
+        }
+        return `<a href="${a.url}" download="${a.name}" class="file-attachment">📎 ${escapeHtml(a.name)}</a>`;
+    }).join('')}
+    </div>`;
+}
+
+export function renderHtmlDocument(
+    title: string,
+    renderedNodes: RenderedNode[],
+    selectedByParent: Record<string, string>
+): string {
+    return `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${escapeHtml(title)}</title>
+    <style>
+        :root {
+            --bg-color: #ffffff;
+            --text-color: #0d0d0d;
+            --user-bg: #f4f4f4;
+            --border-color: #e5e5e5;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg-color: #1e1e1e;
+                --text-color: #ececec;
+                --user-bg: #2f2f2f;
+                --border-color: #444;
+            }
+        }
+
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            margin: 0;
+            padding: 20px;
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding-bottom: 50px;
+        }
+
+        .header {
+            text-align: center;
+            margin-bottom: 40px;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 20px;
+        }
+
+        .header h1 {
+            font-size: 1.5rem;
+            margin: 0;
+        }
+
+        .message {
+            margin-bottom: 24px;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .message.user .bubble {
+            background-color: var(--user-bg);
+            border-radius: 20px;
+            padding: 10px 20px;
+            align-self: flex-end;
+            max-width: 90%;
+            margin-left: auto;
+        }
+
+        .message.assistant .bubble {
+            background-color: transparent;
+            padding: 0;
+            max-width: 100%;
+            align-self: flex-start;
+        }
+        
+        .message.system .bubble {
+            background-color: #fff3cd;
+            color: #856404;
+            border-radius: 8px;
+            padding: 10px;
+            font-size: 0.9em;
+            text-align: center;
+            align-self: center;
+        }
+
+        .message .bubble-toolbar {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            font-size: 0.85em;
+            color: #666;
+            margin-top: 6px;
+            opacity: 0;
+            visibility: hidden;
+            transform: translateY(-2px);
+            transition: opacity 0.15s ease, transform 0.15s ease;
+        }
+
+        .message:hover .bubble-toolbar,
+        .message:focus-within .bubble-toolbar {
+            opacity: 1;
+            visibility: visible;
+            transform: translateY(0);
+        }
+
+        @media (hover: none) {
+            .message .bubble-toolbar {
+                opacity: 1;
+                visibility: visible;
+                transform: none;
+            }
+        }
+
+        .message.user .bubble-toolbar {
+            align-self: flex-end;
+        }
+
+        .message.assistant .bubble-toolbar,
+        .message.tool .bubble-toolbar {
+            align-self: flex-start;
+            flex-direction: row-reverse;
+        }
+
+        .toolbar-btn {
+            border: none;
+            background: transparent;
+            color: inherit;
+            padding: 4px;
+            border-radius: 6px;
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            transition: background 0.15s ease, color 0.15s ease;
+        }
+
+        .toolbar-btn:hover {
+            background: rgba(0, 0, 0, 0.06);
+        }
+
+        @media (prefers-color-scheme: dark) {
+            .toolbar-btn:hover {
+                background: rgba(255, 255, 255, 0.08);
+            }
+        }
+
+        .toolbar-btn:disabled {
+            opacity: 0.4;
+            cursor: default;
+        }
+
+        .toolbar-btn.copied {
+            color: #10a37f;
+        }
+
+        .toolbar-icon {
+            width: 16px;
+            height: 16px;
+        }
+
+        .branch-controls {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .branch-count {
+            min-width: 38px;
+            text-align: center;
+            font-variant-numeric: tabular-nums;
+            color: #444;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            .branch-count {
+                color: #ccc;
+            }
+        }
+
+        .content p {
+            margin: 0.5em 0;
+        }
+        .content p:first-child {
+            margin-top: 0;
+        }
+        .content p:last-child {
+            margin-bottom: 0;
+        }
+
+        .content img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 12px;
+            margin: 10px 0;
+            display: block;
+        }
+
+        .code-block {
+            border: 1px solid var(--border-color);
+            border-radius: 10px;
+            margin: 12px 0;
+            background: transparent;
+        }
+
+        .code-block[data-collapsed="true"] {
+            max-height: var(--code-max-height, 50vh);
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+
+        .code-block[data-collapsed="false"] {
+            max-height: none;
+            overflow: visible;
+        }
+
+        .code-header {
+            position: sticky;
+            top: 0;
+            z-index: 1;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 6px 10px;
+            font-size: 0.85em;
+            background: var(--bg-color);
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .code-block[data-collapsed="false"] .code-header {
+            position: static;
+        }
+
+        .code-title {
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+            color: #666;
+            letter-spacing: 0.02em;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            .code-title {
+                color: #aaa;
+            }
+        }
+
+        .code-actions {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .code-btn {
+            border: 1px solid var(--border-color);
+            background: transparent;
+            color: inherit;
+            padding: 2px 8px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.85em;
+        }
+
+        .code-btn:hover {
+            background: rgba(0, 0, 0, 0.06);
+        }
+
+        @media (prefers-color-scheme: dark) {
+            .code-btn:hover {
+                background: rgba(255, 255, 255, 0.08);
+            }
+        }
+
+        .code-btn.copied {
+            color: #10a37f;
+            border-color: #10a37f;
+        }
+
+        pre {
+            background-color: transparent;
+            border: none;
+            border-radius: 0;
+            padding: 12px;
+            overflow-x: auto;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+            font-size: 0.9em;
+            margin: 0;
+        }
+
+        code {
+            background-color: transparent;
+            padding: 0;
+            border-radius: 0;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+            font-size: 0.9em;
+        }
+
+        :not(pre) > code {
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            padding: 1px 4px;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--border-color);
+            margin: 0;
+            padding-left: 16px;
+            color: #777;
+        }
+
+        .image-carousel {
+            display: flex;
+            gap: 10px;
+            overflow-x: auto;
+            padding: 10px 0;
+            scroll-behavior: smooth;
+        }
+        .image-carousel::-webkit-scrollbar {
+            height: 6px;
+        }
+        .image-carousel::-webkit-scrollbar-thumb {
+            background-color: #ccc;
+            border-radius: 3px;
+        }
+        .image-card {
+            position: relative;
+            flex-shrink: 0;
+        }
+        .image-card img {
+            height: 200px;
+            width: auto;
+            object-fit: cover;
+            border-radius: 8px;
+            display: block;
+            margin: 0;
+        }
+
+        .canvas-block {
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            margin: 10px 0;
+            overflow: hidden;
+        }
+
+        .canvas-header {
+            padding: 8px 12px;
+            border-bottom: 1px solid var(--border-color);
+            font-weight: bold;
+            font-size: 0.9em;
+            display: flex;
+            justify-content: space-between;
+            background: var(--bg-color);
+        }
+
+        .canvas-badge {
+            color: #888;
+            font-weight: normal;
+        }
+
+        .canvas-body {
+            padding: 0;
+        }
+        .image-source {
+            position: absolute;
+            left: 50%;
+            bottom: 8px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+            padding: 4px 8px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.7);
+            color: #111;
+            font-size: 0.75em;
+            text-decoration: none;
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+            max-width: calc(100% - 16px);
+            box-sizing: border-box;
+            transform: translateX(-50%);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.15s ease;
+        }
+        .image-card:hover .image-source,
+        .image-card:focus-within .image-source {
+            opacity: 1;
+            pointer-events: auto;
+        }
+        .image-source img {
+            width: 14px;
+            height: 14px;
+            border-radius: 3px;
+            flex-shrink: 0;
+        }
+        .image-source span {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 180px;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            .image-source {
+                background: rgba(0, 0, 0, 0.55);
+                color: #f0f0f0;
+            }
+        }
+
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>${escapeHtml(title)}</h1>
+        </div>
+        <div class="chat-log">
+            ${renderedNodes.map(m => `
+                <div class="message ${m.role}" data-node-id="${escapeHtmlAttr(m.id)}" data-parent-id="${escapeHtmlAttr(m.parentId)}" data-raw="${escapeHtmlAttr(m.rawText)}">
+                    <div class="bubble">
+                        <div class="content">
+                            ${m.htmlContent}
+                        </div>
+                        ${renderAttachments(m.attachments)}
+                    </div>
+                    <div class="bubble-toolbar">
+                        <button class="toolbar-btn" data-action="copy" title="复制原始内容" aria-label="复制原始内容">
+                            <svg class="toolbar-icon" viewBox="0 0 24 24" aria-hidden="true">
+                                <path fill="currentColor" d="M16 1H6a2 2 0 0 0-2 2v12h2V3h10V1zm3 4H10a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H10V7h9v14z"/>
+                            </svg>
+                        </button>
+                        <div class="branch-controls">
+                            <button class="toolbar-btn" data-action="prev" title="上一版本" aria-label="上一版本">
+                                <svg class="toolbar-icon" viewBox="0 0 24 24" aria-hidden="true">
+                                    <path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>
+                                </svg>
+                            </button>
+                            <span class="branch-count">1/1</span>
+                            <button class="toolbar-btn" data-action="next" title="下一版本" aria-label="下一版本">
+                                <svg class="toolbar-icon" viewBox="0 0 24 24" aria-hidden="true">
+                                    <path fill="currentColor" d="m8.59 16.59 1.41 1.41 6-6-6-6-1.41 1.41L13.17 12z"/>
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            `).join('')}
+        </div>
+    </div>
+    <script>
+        (() => {
+            const ROOT_ID = ${JSON.stringify(VIRTUAL_ROOT_ID)};
+            const selectedByParent = ${JSON.stringify(selectedByParent)};
+            const messageEls = Array.from(document.querySelectorAll('.message[data-node-id]'));
+            const childrenByParent = new Map();
+
+            messageEls.forEach((el) => {
+                const nodeId = el.dataset.nodeId || '';
+                const parentId = el.dataset.parentId || ROOT_ID;
+                if (!childrenByParent.has(parentId)) childrenByParent.set(parentId, []);
+                childrenByParent.get(parentId).push(nodeId);
+            });
+
+            const getSelectedChild = (parentId) => {
+                const children = childrenByParent.get(parentId) || [];
+                if (!children.length) return null;
+                const selected = selectedByParent[parentId];
+                if (selected && children.includes(selected)) return selected;
+                return children[0];
+            };
+
+            const updateBranchControls = () => {
+                messageEls.forEach((el) => {
+                    const nodeId = el.dataset.nodeId || '';
+                    const parentId = el.dataset.parentId || ROOT_ID;
+                    const siblings = childrenByParent.get(parentId) || [];
+                    const total = siblings.length;
+                    const index = Math.max(0, siblings.indexOf(nodeId));
+                    const countEl = el.querySelector('.branch-count');
+                    if (countEl) countEl.textContent = total ? (index + 1) + '/' + total : '1/1';
+                    const prevBtn = el.querySelector('[data-action="prev"]');
+                    const nextBtn = el.querySelector('[data-action="next"]');
+                    if (prevBtn) prevBtn.disabled = total <= 1 || index <= 0;
+                    if (nextBtn) nextBtn.disabled = total <= 1 || index >= total - 1;
+                });
+            };
+
+            const updateVisibility = () => {
+                const visible = new Set();
+                const walk = (parentId) => {
+                    const child = getSelectedChild(parentId);
+                    if (!child) return;
+                    visible.add(child);
+                    walk(child);
+                };
+                walk(ROOT_ID);
+                messageEls.forEach((el) => {
+                    const nodeId = el.dataset.nodeId || '';
+                    el.style.display = visible.has(nodeId) ? '' : 'none';
+                });
+                updateBranchControls();
+            };
+
+            const setCodeToggleState = (block, btn, collapsed) => {
+                block.dataset.collapsed = collapsed ? 'true' : 'false';
+                btn.textContent = collapsed ? '展开' : '收起';
+                btn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+            };
+
+            const setupCodeBlocks = () => {
+                const maxHeight = Math.round(window.innerHeight * 0.5);
+                const blocks = document.querySelectorAll('pre > code');
+                blocks.forEach((codeEl) => {
+                    const pre = codeEl.parentElement;
+                    if (!pre || pre.closest('.code-block')) return;
+                    const wrapper = document.createElement('div');
+                    wrapper.className = 'code-block';
+                    wrapper.style.setProperty('--code-max-height', maxHeight + 'px');
+
+                    const header = document.createElement('div');
+                    header.className = 'code-header';
+
+                    const title = document.createElement('span');
+                    title.className = 'code-title';
+                    const match = (codeEl.className || '').match(/language-([a-z0-9_-]+)/i);
+                    title.textContent = match ? match[1].toUpperCase() : 'CODE';
+
+                    const actions = document.createElement('div');
+                    actions.className = 'code-actions';
+
+                    const copyBtn = document.createElement('button');
+                    copyBtn.type = 'button';
+                    copyBtn.className = 'code-btn';
+                    copyBtn.setAttribute('data-code-action', 'copy');
+                    copyBtn.textContent = '复制';
+
+                    const toggleBtn = document.createElement('button');
+                    toggleBtn.type = 'button';
+                    toggleBtn.className = 'code-btn';
+                    toggleBtn.setAttribute('data-code-action', 'toggle');
+                    toggleBtn.textContent = '展开';
+                    toggleBtn.setAttribute('aria-expanded', 'false');
+
+                    actions.append(copyBtn, toggleBtn);
+                    header.append(title, actions);
+
+                    pre.parentNode.insertBefore(wrapper, pre);
+                    wrapper.append(header, pre);
+
+                    const needsCollapse = pre.scrollHeight > maxHeight;
+                    if (needsCollapse) {
+                        setCodeToggleState(wrapper, toggleBtn, true);
+                    } else {
+                        wrapper.dataset.collapsed = 'false';
+                        toggleBtn.hidden = true;
+                    }
+                });
+            };
+
+            document.addEventListener('click', (event) => {
+                const btn = event.target.closest('[data-action]');
+                if (!btn) return;
+                const action = btn.getAttribute('data-action');
+                const messageEl = btn.closest('.message');
+                if (!messageEl) return;
+                const nodeId = messageEl.dataset.nodeId || '';
+                const parentId = messageEl.dataset.parentId || ROOT_ID;
+                const siblings = childrenByParent.get(parentId) || [];
+                const index = siblings.indexOf(nodeId);
+                if (action === 'copy') {
+                    const raw = messageEl.dataset.raw || '';
+                    if (navigator.clipboard && navigator.clipboard.writeText) {
+                        navigator.clipboard.writeText(raw).then(() => {
+                            btn.classList.add('copied');
+                            setTimeout(() => btn.classList.remove('copied'), 900);
+                        }).catch(() => {
+                        });
+                    } else {
+                        const helper = document.createElement('textarea');
+                        helper.value = raw;
+                        helper.style.position = 'fixed';
+                        helper.style.opacity = '0';
+                        document.body.appendChild(helper);
+                        helper.select();
+                        try { document.execCommand('copy'); } catch (e) {}
+                        document.body.removeChild(helper);
+                        btn.classList.add('copied');
+                        setTimeout(() => btn.classList.remove('copied'), 900);
+                    }
+                    return;
+                }
+                if (action === 'prev' && index > 0) {
+                    selectedByParent[parentId] = siblings[index - 1];
+                    updateVisibility();
+                }
+                if (action === 'next' && index >= 0 && index < siblings.length - 1) {
+                    selectedByParent[parentId] = siblings[index + 1];
+                    updateVisibility();
+                }
+            });
+
+            document.addEventListener('click', (event) => {
+                const btn = event.target.closest('[data-code-action]');
+                if (!btn) return;
+                const action = btn.getAttribute('data-code-action');
+                const block = btn.closest('.code-block');
+                if (!block) return;
+                if (action === 'copy') {
+                    const codeEl = block.querySelector('code');
+                    const text = codeEl ? (codeEl.textContent || '') : '';
+                    if (navigator.clipboard && navigator.clipboard.writeText) {
+                        navigator.clipboard.writeText(text).then(() => {
+                            btn.classList.add('copied');
+                            setTimeout(() => btn.classList.remove('copied'), 900);
+                        }).catch(() => {
+                        });
+                    } else {
+                        const helper = document.createElement('textarea');
+                        helper.value = text;
+                        helper.style.position = 'fixed';
+                        helper.style.opacity = '0';
+                        document.body.appendChild(helper);
+                        helper.select();
+                        try { document.execCommand('copy'); } catch (e) {}
+                        document.body.removeChild(helper);
+                        btn.classList.add('copied');
+                        setTimeout(() => btn.classList.remove('copied'), 900);
+                    }
+                    return;
+                }
+                if (action === 'toggle') {
+                    const collapsed = block.dataset.collapsed !== 'true';
+                    setCodeToggleState(block, btn, collapsed);
+                }
+            });
+
+            const normalizeWheelDelta = (event, target) => {
+                const absX = Math.abs(event.deltaX || 0);
+                const absY = Math.abs(event.deltaY || 0);
+                let delta = absX > absY ? event.deltaX : event.deltaY;
+                if (!delta) return 0;
+                if (event.deltaMode === 1) delta *= 16;
+                if (event.deltaMode === 2) delta *= target.clientWidth;
+                return delta;
+            };
+
+            document.addEventListener('wheel', (event) => {
+                if (event.ctrlKey) return;
+                const target = event.target;
+                if (!(target instanceof Element)) return;
+                const carousel = target.closest('.image-carousel');
+                if (!carousel) return;
+                const maxScroll = carousel.scrollWidth - carousel.clientWidth;
+                if (maxScroll <= 0) return;
+                const delta = normalizeWheelDelta(event, carousel);
+                if (!delta) return;
+                const prev = carousel.scrollLeft;
+                let next = prev + delta;
+                if (next < 0) next = 0;
+                if (next > maxScroll) next = maxScroll;
+                if (next === prev) return;
+                carousel.scrollLeft = next;
+                event.preventDefault();
+            }, { passive: false });
+
+            setupCodeBlocks();
+            updateVisibility();
+        })();
+    </script>
+</body>
+</html>`;
+}

--- a/src/html/tree.ts
+++ b/src/html/tree.ts
@@ -1,0 +1,139 @@
+import { Conversation } from '../types';
+import { getThoughtsText } from './utils';
+import { getRawMessageText, renderMessage } from './messages';
+import type { CanvasState, ExportedAttachment, RenderedNode } from './types';
+
+export const VIRTUAL_ROOT_ID = '__root__';
+
+function cloneCanvasState(state: CanvasState): CanvasState {
+    return {
+        lastName: state.lastName,
+        lastContent: state.lastContent,
+        byName: { ...state.byName }
+    };
+}
+
+function hasRenderableContent(msg: any): boolean {
+    const content = msg.content;
+    const contentType = content?.content_type;
+    if (contentType === 'text') {
+        if (Array.isArray(content?.parts)) {
+            return content.parts.some((part: any) =>
+                typeof part === 'string' ? part.trim() !== '' : Boolean(part)
+            );
+        }
+        if (typeof content?.text === 'string') {
+            return content.text.trim() !== '';
+        }
+        return false;
+    }
+    if (contentType === 'thoughts') {
+        return getThoughtsText(content).trim() !== '';
+    }
+    if (contentType === 'reasoning_recap') {
+        return typeof content?.content === 'string' && content.content.trim() !== '';
+    }
+    if (contentType === 'multimodal_text') {
+        return Array.isArray(content?.parts) && content.parts.length > 0;
+    }
+    return Boolean(content);
+}
+
+function shouldRenderMessage(msg: any): boolean {
+    if (!msg) return false;
+    const isHidden = msg.metadata?.is_visually_hidden_from_conversation;
+    if (isHidden) return false;
+    const isLoadingMessage = msg.metadata?.is_loading_message === true;
+    if (isLoadingMessage) return false;
+    if (!hasRenderableContent(msg)) return false;
+    if (!['user', 'assistant', 'tool'].includes(msg.author.role)) return false;
+    if (msg.author.role === 'tool') {
+        const toolName = msg.author.name || '';
+        const isInternalTool =
+            toolName === 'file_search' ||
+            toolName.startsWith('canmore.') ||
+            toolName.startsWith('research_kickoff_tool.') ||
+            Boolean(msg.metadata?.canvas);
+        if (isInternalTool) return false;
+    }
+    if (msg.author.role === 'assistant' && typeof msg.recipient === 'string') {
+        if (msg.recipient.startsWith('research_kickoff_tool.')) return false;
+    }
+    if (msg.content?.content_type === 'model_editable_context') return false;
+    return true;
+}
+
+function extractRenderablePathIds(conv: Conversation, renderableIds: Set<string>): string[] {
+    const ids: string[] = [];
+    let currentId = conv.current_node;
+    while (currentId) {
+        const node = conv.mapping[currentId];
+        if (!node) break;
+        if (renderableIds.has(currentId)) ids.unshift(currentId);
+        if (!node.parent) break;
+        currentId = node.parent;
+    }
+    return ids;
+}
+
+export function buildRenderedNodes(
+    conv: Conversation,
+    attachments: ExportedAttachment[]
+): { nodes: RenderedNode[]; selectedByParent: Record<string, string> } {
+    const mapping = conv.mapping || {};
+    const renderableIds = new Set<string>();
+    for (const node of Object.values(mapping)) {
+        if (node?.message && shouldRenderMessage(node.message)) {
+            renderableIds.add(node.id);
+        }
+    }
+
+    const visibleParentById: Record<string, string> = {};
+    for (const id of renderableIds) {
+        let parentId = mapping[id]?.parent || null;
+        while (parentId && !renderableIds.has(parentId)) {
+            parentId = mapping[parentId]?.parent || null;
+        }
+        visibleParentById[id] = parentId || VIRTUAL_ROOT_ID;
+    }
+
+    const renderedNodes: RenderedNode[] = [];
+    const rootIds = Object.values(mapping).filter((node) => !node.parent).map((node) => node.id);
+
+    const traverse = (nodeId: string, canvasState: CanvasState) => {
+        const node = mapping[nodeId];
+        if (!node) return;
+        const msg = node.message;
+        let nextState = canvasState;
+        if (msg && renderableIds.has(nodeId)) {
+            const localState = cloneCanvasState(canvasState);
+            const rendered = renderMessage(msg, attachments, localState);
+            renderedNodes.push({
+                id: nodeId,
+                parentId: visibleParentById[nodeId],
+                role: rendered.role,
+                htmlContent: rendered.htmlContent,
+                modelSlug: rendered.modelSlug,
+                attachments: rendered.attachments,
+                rawText: getRawMessageText(msg, attachments)
+            });
+            nextState = localState;
+        }
+        for (const childId of node.children || []) {
+            traverse(childId, cloneCanvasState(nextState));
+        }
+    };
+
+    rootIds.forEach((rootId) => {
+        traverse(rootId, { byName: {} });
+    });
+
+    const selectedByParent: Record<string, string> = {};
+    const pathIds = extractRenderablePathIds(conv, renderableIds);
+    for (const id of pathIds) {
+        const parentId = visibleParentById[id] || VIRTUAL_ROOT_ID;
+        selectedByParent[parentId] = id;
+    }
+
+    return { nodes: renderedNodes, selectedByParent };
+}

--- a/src/html/types.ts
+++ b/src/html/types.ts
@@ -1,0 +1,35 @@
+export interface RenderedAttachment {
+    url: string;
+    name: string;
+    isImage: boolean;
+}
+
+export interface RenderedMessage {
+    role: string;
+    htmlContent: string;
+    modelSlug?: string;
+    attachments: RenderedAttachment[];
+}
+
+export interface RenderedNode extends RenderedMessage {
+    id: string;
+    parentId: string;
+    rawText: string;
+}
+
+export interface CanvasState {
+    lastName?: string;
+    lastContent?: string;
+    byName: Record<string, string>;
+}
+
+export interface ExportedAttachment {
+    id?: string;
+    file_id?: string;
+    pointer?: string;
+    name?: string;
+    original_name?: string;
+    saved_as?: string;
+    mime?: string;
+    [key: string]: any;
+}

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -1,0 +1,88 @@
+export function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
+export function escapeHtmlAttr(text: string): string {
+    return escapeHtml(text)
+        .replace(/\n/g, "&#10;")
+        .replace(/\r/g, "&#13;");
+}
+
+export function stripChatgptUtm(url: string): string {
+    try {
+        const parsed = new URL(url);
+        if (parsed.searchParams.has('utm_source')) {
+            parsed.searchParams.delete('utm_source');
+        }
+        return parsed.toString();
+    } catch (e) {
+        return url.replace(/([?&])utm_source=chatgpt\.com(&|$)/, (_match, p1, p2) => {
+            if (p2 === '&') return p1;
+            return '';
+        });
+    }
+}
+
+export function getHostname(url: string): string {
+    try {
+        return new URL(url).hostname.replace(/^www\./, '');
+    } catch (e) {
+        return url;
+    }
+}
+
+export function getFaviconUrl(url: string): string {
+    try {
+        const parsed = new URL(url);
+        return `${parsed.origin}/favicon.ico`;
+    } catch (e) {
+        return '';
+    }
+}
+
+export function getThoughtsText(content: any): string {
+    if (!content) return '';
+    if (Array.isArray(content.parts)) {
+        return content.parts
+            .map((part: any) => (typeof part === 'string' ? part : part?.text || part?.content || ''))
+            .filter((part: string) => part.trim() !== '')
+            .join('\n');
+    }
+    if (Array.isArray(content.thoughts)) {
+        return content.thoughts
+            .map((thought: any) => (typeof thought === 'string' ? thought : thought?.text || thought?.content || ''))
+            .filter((thought: string) => thought.trim() !== '')
+            .join('\n');
+    }
+    if (typeof content.thoughts === 'string') {
+        return content.thoughts;
+    }
+    if (typeof content.text === 'string') {
+        return content.text;
+    }
+    return '';
+}
+
+export function normalizeListIndentation(text: string): string {
+    const lines = text.split('\n');
+    let inFence = false;
+    const fenceRegex = /^(```|~~~)/;
+    const listRegex = /^([ \t\u00a0\u3000]{1,3})(\d+\.[ \t]+|[-*+][ \t]+)/;
+
+    return lines.map(line => {
+        const trimmed = line.trimStart();
+        if (fenceRegex.test(trimmed)) {
+            inFence = !inFence;
+            return line;
+        }
+        if (inFence) return line;
+        const match = line.match(listRegex);
+        if (!match) return line;
+        return line.slice(match[1].length);
+    }).join('\n');
+}

--- a/src/htmlGenerator.ts
+++ b/src/htmlGenerator.ts
@@ -1,0 +1,12 @@
+import { Conversation } from './types';
+import { buildRenderedNodes } from './html/tree';
+import { renderHtmlDocument } from './html/template';
+import type { ExportedAttachment } from './html/types';
+
+export type { ExportedAttachment } from './html/types';
+
+export function generateHTML(conversation: Conversation, attachments: ExportedAttachment[]): string {
+    const title = conversation.title || 'Conversation';
+    const { nodes: renderedNodes, selectedByParent } = buildRenderedNodes(conversation, attachments);
+    return renderHtmlDocument(title, renderedNodes, selectedByParent);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,10 +39,14 @@ export interface Message {
   recipient: string;
 }
 
+export type ThoughtItem = string | { text?: string; content?: string };
+
 export interface MessageContent {
   content_type: string;
   parts?: any[];
   text?: string; // Legacy or simple text
+  content?: string; // reasoning recap payloads
+  thoughts?: ThoughtItem[] | string; // reasoning payloads
 }
 
 export interface MessageMetadata {


### PR DESCRIPTION
## 背景
为导出结果提供可直接阅读的 HTML 版本，便于离线查看、分享与归档。

## 变更概览
- 新增 HTML 渲染与模板（消息树、分支切换、复制/代码折叠、引用与附件渲染等）
- 导出 HTML 时对内容进行基础安全清洗（避免不安全标签/属性）
- 自动保存与批量导出均写出 conversation.html
- 依赖更新：新增 marked（Node >= 18）

## 自动保存文件结构变化
之前
```
User/
  Workspace/
    conversations/
      <conversation_id>/
        conversation.json
        metadata.json
        attachments/
          ...
```

现在（新增 HTML）
```
User/
  Workspace/
    conversations/
      <title><conversation_id>/    <-- 修改
        conversation.json
        metadata.json
        conversation.html   <-- 新增
        attachments/
          ...
```

## HTML 导出能力补充说明
- 支持附件展示与下载、引用链接、图片组、Canvas/HTML 片段等
- 支持会话分支切换与代码块折叠/复制

## 截图
- <img width="2560" height="1467" alt="创建图像" src="https://github.com/user-attachments/assets/e5d7d164-26ba-4ecd-809c-fb646ae7c116" />
- <img width="2560" height="1467" alt="canvas" src="https://github.com/user-attachments/assets/fc01a0c3-d2d3-434a-ab4f-879f54c11c29" />
- <img width="2560" height="1467" alt="搜索网页" src="https://github.com/user-attachments/assets/2010f7c3-251f-45c1-b219-df27a4bdc88d" />
- <img width="2560" height="1467" alt="深度研究" src="https://github.com/user-attachments/assets/4d6602a1-4007-4e73-b8be-56664a0ae1d0" />
