### PR TITLE
fix: stabilize sidebar toolbar layout and autosave behavior

### DIFF
--- a/src/autoSave.ts
+++ b/src/autoSave.ts
@@ -354,14 +354,15 @@ async function leaderLoop() {
 
 // Global start function
 export async function startAutoSaveLoop(intervalMs: number = 5 * 60 * 1000) {
+    const previousIntervalMs = currentIntervalMs;
     currentIntervalMs = intervalMs;
 
     if (isStarted) {
-        // If already started, just ensure the interval is updated (which we did above)
-        // And optionally wake up the loop to apply it immediately?
-        // For now, next cycle will pick it up, or if we want immediate effect:
-        if (autoSaveStore.role.value === 'leader' && interruptSleep) {
-            Logger.info('AutoSave', 'Updating interval on running loop');
+        // Avoid waking the loop on repeated init calls from UI remounts.
+        // Only interrupt sleep when the interval is actually changed.
+        const intervalChanged = previousIntervalMs !== intervalMs;
+        if (intervalChanged && autoSaveStore.role.value === 'leader' && interruptSleep) {
+            Logger.info('AutoSave', `Updating interval from ${previousIntervalMs}ms to ${intervalMs}ms`);
             interruptSleep();
         }
         return;

--- a/src/cred.ts
+++ b/src/cred.ts
@@ -135,14 +135,16 @@ export const Cred = (() => {
     // CLIENT_BOOTSTRAP for User Email and Account ID
     try {
       // https://deepwiki.com/search/unsafewindowlet-bs-unsafewindo_7d2850f6-596f-4cad-8791-de7557543ad6?mode=fast
-      let bs = unsafeWindow.CLIENT_BOOTSTRAP;
-      console.log(bs);
-      console.log('[Cred] CLIENT_BOOTSTRAP inspection:', {
+      const bs = unsafeWindow.CLIENT_BOOTSTRAP;
+      if (Logger.isDebug()) {
+        console.log('[Cred] CLIENT_BOOTSTRAP raw:', bs);
+      }
+      Logger.debug('Cred', 'CLIENT_BOOTSTRAP inspection:', {
         exists: !!bs,
         source: 'unsafeWindow',
         hasUser: !!bs?.user,
         email: bs?.user?.email,
-        session: !!bs?.session
+        session: !!bs?.session,
       });
 
       if (bs) {

--- a/src/files.ts
+++ b/src/files.ts
@@ -48,17 +48,6 @@ export function collectFileCandidates(conv: Conversation): FileCandidate[] {
           const fid = pointerToFileId(part.asset_pointer);
           add(fid, { source: part.content_type, pointer: part.asset_pointer, meta: part, message_id: msg.id });
         }
-        if (
-          part &&
-          typeof part === 'object' &&
-          part.content_type === 'real_time_user_audio_video_asset_pointer' &&
-          part.audio_asset_pointer &&
-          part.audio_asset_pointer.asset_pointer
-        ) {
-          const ap = part.audio_asset_pointer;
-          const fid = pointerToFileId(ap.asset_pointer);
-          add(fid, { source: 'voice-audio', pointer: ap.asset_pointer, meta: ap, message_id: msg.id });
-        }
         if (part && typeof part === 'object' && part.audio_asset_pointer && part.audio_asset_pointer.asset_pointer) {
           const ap = part.audio_asset_pointer;
           const fid = pointerToFileId(ap.asset_pointer);
@@ -149,4 +138,3 @@ export function extractImages(conv: Conversation): FileCandidate[] {
   console.log('[ChatGPT-Multimodal-Exporter] 找到的图片信息：', images);
   return images;
 }
-

--- a/src/style.css
+++ b/src/style.css
@@ -1,61 +1,63 @@
 .cgptx-mini-wrap {
-  position: fixed;
-  right: 16px;
-  bottom: 16px;
-  z-index: 2147483647;
+  /* position: fixed; */
+  /* right: 16px; */
+  /* bottom: 16px; */
+  /* z-index: 2147483647; */
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  flex-direction: row; /* Horizontal layout for sidebar */
+  align-items: center;
   gap: 8px;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin-left: auto; /* Push to the right, next to collapse button */
+  margin-right: 8px; /* Spacing from collapse button */
 }
 .cgptx-mini-badge {
   font-size: 12px;
-  padding: 4px 8px;
-  border-radius: 999px;
-  background: #ffffff;
-  color: #374151;
-  border: 1px solid #e5e7eb;
-  max-width: 260px;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  width: 8px;
+  height: 8px;
+  padding: 0;
+  border-radius: 50%;
+  text-indent: -9999px; /* Hide text, show only color */
+  border: 1px solid transparent;
   overflow: hidden;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+  box-shadow: none;
+  cursor: help;
 }
 .cgptx-mini-badge.ok {
-  background: #ecfdf5;
+  background: #3fd991;
   border-color: #a7f3d0;
   color: #047857;
 }
 .cgptx-mini-badge.bad {
-  background: #fef2f2;
+  background: #d43939;
   border-color: #fecaca;
   color: #b91c1c;
 }
 .cgptx-mini-btn-row {
   display: flex;
-  gap: 8px;
+  gap: 4px; /* Tighter gap for sidebar */
 }
 .cgptx-mini-btn {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  border: 1px solid #e5e7eb;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  border: none;
   cursor: pointer;
-  background: #ffffff;
-  color: #4b5563;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  background: transparent;
+  color: #8e8ea0; /* Standard sidebar icon color */
+  box-shadow: none; /* Remove shadow for flat look */
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 22px;
+  font-size: 16px; /* Smaller icon size */
   transition: all .2s ease;
 }
 .cgptx-mini-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
-  color: #2563eb;
-  border-color: #bfdbfe;
+  background: rgba(255, 255, 255, 0.1); /* Ghost hover effect */
+  color: #d9d9e3;
+  transform: none;
+  box-shadow: none;
+  border-color: transparent;
 }
 .cgptx-mini-btn:disabled {
   opacity: .6;
@@ -351,10 +353,10 @@
 /* StatusPanel Styles */
 .cgptx-mini-badges-col {
   display: flex; 
-  flex-direction: column; 
+  flex-direction: row; /* Horizontal status layout */
   gap: 4px; 
-  margin-bottom: 8px; 
-  align-items: flex-end;
+  margin-bottom: 0; 
+  align-items: center;
 }
 
 .cgptx-mini-badge.info {

--- a/src/style.css
+++ b/src/style.css
@@ -1,23 +1,48 @@
 .cgptx-mini-wrap {
-  /* position: fixed; */
-  /* right: 16px; */
-  /* bottom: 16px; */
-  /* z-index: 2147483647; */
   display: flex;
-  flex-direction: row; /* Horizontal layout for sidebar */
+  flex-direction: row;
   align-items: center;
-  gap: 8px;
+  position: relative;
+  height: 36px;
+  gap: 6px;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  margin-left: auto; /* Push to the right, next to collapse button */
-  margin-right: 8px; /* Spacing from collapse button */
+  margin: 0;
+}
+.cgptx-status-anchor {
+  position: relative;
+}
+#cgptx-sidebar-root[data-mode="expanded"] {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 36px;
+}
+#cgptx-sidebar-root[data-mode="expanded"] .cgptx-mini-wrap {
+  width: 100%;
+  gap: 0;
+}
+#cgptx-sidebar-root[data-mode="collapsed"] {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+#cgptx-sidebar-root[data-mode="collapsed"] .cgptx-mini-wrap {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  gap: 0;
+}
+#cgptx-sidebar-root[data-mode="collapsed"] .cgptx-mini-badges-col {
+  left: auto;
+  right: 4px;
+  top: 2px;
 }
 .cgptx-mini-badge {
   font-size: 12px;
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
   padding: 0;
   border-radius: 50%;
-  text-indent: -9999px; /* Hide text, show only color */
+  text-indent: -9999px;
   border: 1px solid transparent;
   overflow: hidden;
   box-shadow: none;
@@ -35,35 +60,57 @@
 }
 .cgptx-mini-btn-row {
   display: flex;
-  gap: 4px; /* Tighter gap for sidebar */
+  align-items: center;
+  height: 36px;
+  gap: 2px;
+}
+#cgptx-sidebar-root[data-mode="expanded"] .cgptx-mini-btn-row {
+  --cgptx-slot-gap: clamp(2px, calc((100% - 144px) / 5), 12px);
+  width: 100%;
+  justify-content: space-between;
+  gap: 0;
+  padding-inline: var(--cgptx-slot-gap);
 }
 .cgptx-mini-btn {
-  width: 28px;
-  height: 28px;
-  border-radius: 4px;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
   border: none;
+  padding: 0;
   cursor: pointer;
   background: transparent;
-  color: #8e8ea0; /* Standard sidebar icon color */
-  box-shadow: none; /* Remove shadow for flat look */
+  color: #8f8f8f;
+  box-shadow: none;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px; /* Smaller icon size */
-  transition: all .2s ease;
+  font-size: 16px;
+  line-height: 1;
+  transition: background-color .15s ease, color .15s ease;
 }
 .cgptx-mini-btn:hover {
-  background: rgba(255, 255, 255, 0.1); /* Ghost hover effect */
-  color: #d9d9e3;
+  background: rgba(255, 255, 255, 0.08);
+  color: #e8e8e8;
   transform: none;
   box-shadow: none;
   border-color: transparent;
+}
+.cgptx-mini-btn:focus-visible {
+  outline: 2px solid #6ea8fe;
+  outline-offset: -2px;
 }
 .cgptx-mini-btn:disabled {
   opacity: .6;
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
+}
+html.light .cgptx-mini-btn {
+  color: #6b7280;
+}
+html.light .cgptx-mini-btn:hover {
+  background: rgba(15, 23, 42, 0.08);
+  color: #111827;
 }
 .cgptx-modal {
   position: fixed;
@@ -352,11 +399,19 @@
 }
 /* StatusPanel Styles */
 .cgptx-mini-badges-col {
-  display: flex; 
-  flex-direction: row; /* Horizontal status layout */
-  gap: 4px; 
-  margin-bottom: 0; 
+  position: absolute;
+  top: 2px;
+  left: -17px;
+  right: auto;
+  z-index: 2;
+  display: flex;
+  flex-direction: row;
   align-items: center;
+  justify-content: center;
+  width: 10px;
+  height: 10px;
+  gap: 0;
+  margin-bottom: 0;
 }
 
 .cgptx-mini-badge.info {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,4 +1,4 @@
-import { render, h, Fragment } from 'preact';
+import { render, h } from 'preact';
 import { isHostOK } from './utils';
 import './style.css';
 import { FloatingEntry } from './ui/components/FloatingEntry';
@@ -6,15 +6,49 @@ import { Toaster } from './ui/components/Toaster';
 
 export function mountUI() {
   if (!isHostOK()) return;
-  if (document.querySelector('.cgptx-mini-wrap')) return;
 
-  const root = document.createElement('div');
-  document.body.appendChild(root);
-  render(
-    h(Fragment, null,
-      h(FloatingEntry, null),
-      h(Toaster, null)
-    ),
-    root
-  );
+  // Mount Toaster independently to document.body
+  const toasterRoot = document.createElement('div');
+  document.body.appendChild(toasterRoot);
+  render(h(Toaster, null), toasterRoot);
+
+  const mountFloatingEntry = () => {
+    if (document.querySelector('.cgptx-mini-wrap')) return;
+    const sidebarHeader = document.querySelector('#sidebar-header');
+    
+    if (sidebarHeader) {
+      const root = document.createElement('div');
+      
+      // Try to find the collapse button wrapper to insert before it
+      // Based on structure: [Logo] [MyUI] [CollapseWrapper]
+      const closeBtn = sidebarHeader.querySelector('[data-testid="close-sidebar-button"]');
+      // The button is wrapped in a div.flex, we need to insert before that div
+      const targetContainer = closeBtn?.closest('div.flex'); 
+      // Or just fallback to the last element if structure matches expectations (2 children initially)
+      const insertTarget = (targetContainer && targetContainer.parentElement === sidebarHeader) 
+        ? targetContainer 
+        : null;
+
+      if (insertTarget) {
+          sidebarHeader.insertBefore(root, insertTarget);
+      } else {
+          // Fallback
+          sidebarHeader.appendChild(root);
+      }
+      
+      render(h(FloatingEntry, null), root);
+    }
+  };
+
+  // Check immediately
+  mountFloatingEntry();
+
+  // Poll for sidebar header presence (it might load dynamically)
+  const intervalId = setInterval(() => {
+    if (document.querySelector('.cgptx-mini-wrap')) {
+      clearInterval(intervalId);
+      return;
+    }
+    mountFloatingEntry();
+  }, 1000);
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -4,51 +4,131 @@ import './style.css';
 import { FloatingEntry } from './ui/components/FloatingEntry';
 import { Toaster } from './ui/components/Toaster';
 
+const TOASTER_ROOT_ID = 'cgptx-toaster-root';
+const SIDEBAR_ROOT_ID = 'cgptx-sidebar-root';
+const COLLAPSED_ANCHOR_CLASS = 'cgptx-status-anchor';
+
+let sidebarObserver: MutationObserver | null = null;
+let collapsedAnchor: HTMLElement | null = null;
+let sidebarPollTimer: number | null = null;
+
+function isVisible(el: Element | null): el is HTMLElement {
+  if (!(el instanceof HTMLElement)) return false;
+  if (typeof el.checkVisibility === 'function') {
+    return el.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true });
+  }
+  return el.getClientRects().length > 0;
+}
+
+function setCollapsedAnchor(el: HTMLElement | null) {
+  if (collapsedAnchor && collapsedAnchor !== el) {
+    collapsedAnchor.classList.remove(COLLAPSED_ANCHOR_CLASS);
+  }
+  collapsedAnchor = el;
+  if (collapsedAnchor) {
+    collapsedAnchor.classList.add(COLLAPSED_ANCHOR_CLASS);
+  }
+}
+
+function findOpenSidebarButton(): HTMLElement | null {
+  const byTestId = document.querySelector('[data-testid="open-sidebar-button"]');
+  if (isVisible(byTestId)) return byTestId;
+
+  const btns = Array.from(document.querySelectorAll('button'));
+  const found = btns.find((b) => {
+    const label = `${b.getAttribute('aria-label') || ''} ${b.getAttribute('title') || ''}`.toLowerCase();
+    return (label.includes('open sidebar') || label.includes('打开边栏')) && isVisible(b);
+  });
+  return (found as HTMLElement) || null;
+}
+
+function ensureToasterMounted() {
+  if (document.getElementById(TOASTER_ROOT_ID)) return;
+  const toasterRoot = document.createElement('div');
+  toasterRoot.id = TOASTER_ROOT_ID;
+  document.body.appendChild(toasterRoot);
+  render(h(Toaster, null), toasterRoot);
+}
+
+function mountFloatingEntry() {
+  const sidebarHeader = document.querySelector('#sidebar-header');
+  const closeSidebarBtn = sidebarHeader?.querySelector('[data-testid="close-sidebar-button"]') as HTMLElement | null;
+  const isExpanded = !!(sidebarHeader && isVisible(closeSidebarBtn));
+  const openSidebarBtn = findOpenSidebarButton();
+  const existingRoot = document.getElementById(SIDEBAR_ROOT_ID);
+
+  if (!isExpanded && !openSidebarBtn) {
+    if (existingRoot) {
+      existingRoot.remove();
+    }
+    setCollapsedAnchor(null);
+    return;
+  }
+
+  const mode = isExpanded ? 'expanded' : 'collapsed';
+  const mountParent = (mode === 'expanded'
+    ? sidebarHeader
+    : (openSidebarBtn?.parentElement || openSidebarBtn)) as HTMLElement;
+
+  if (mode === 'collapsed') {
+    setCollapsedAnchor(mountParent);
+  } else {
+    setCollapsedAnchor(null);
+  }
+
+  if (
+    existingRoot &&
+    existingRoot.parentElement === mountParent &&
+    existingRoot.getAttribute('data-mode') === mode
+  ) {
+    return;
+  }
+
+  if (existingRoot) {
+    existingRoot.remove();
+  }
+
+  const root = document.createElement('div');
+  root.id = SIDEBAR_ROOT_ID;
+  root.setAttribute('data-mode', mode);
+
+  if (mode === 'expanded' && sidebarHeader) {
+    const targetContainer = closeSidebarBtn?.closest('div.flex');
+    const insertTarget = targetContainer && targetContainer.parentElement === sidebarHeader
+      ? targetContainer
+      : null;
+
+    if (insertTarget) {
+      sidebarHeader.insertBefore(root, insertTarget);
+    } else {
+      sidebarHeader.appendChild(root);
+    }
+    render(h(FloatingEntry, { collapsed: false }), root);
+    return;
+  }
+
+  mountParent.appendChild(root);
+  render(h(FloatingEntry, { collapsed: true }), root);
+}
+
 export function mountUI() {
   if (!isHostOK()) return;
 
-  // Mount Toaster independently to document.body
-  const toasterRoot = document.createElement('div');
-  document.body.appendChild(toasterRoot);
-  render(h(Toaster, null), toasterRoot);
-
-  const mountFloatingEntry = () => {
-    if (document.querySelector('.cgptx-mini-wrap')) return;
-    const sidebarHeader = document.querySelector('#sidebar-header');
-    
-    if (sidebarHeader) {
-      const root = document.createElement('div');
-      
-      // Try to find the collapse button wrapper to insert before it
-      // Based on structure: [Logo] [MyUI] [CollapseWrapper]
-      const closeBtn = sidebarHeader.querySelector('[data-testid="close-sidebar-button"]');
-      // The button is wrapped in a div.flex, we need to insert before that div
-      const targetContainer = closeBtn?.closest('div.flex'); 
-      // Or just fallback to the last element if structure matches expectations (2 children initially)
-      const insertTarget = (targetContainer && targetContainer.parentElement === sidebarHeader) 
-        ? targetContainer 
-        : null;
-
-      if (insertTarget) {
-          sidebarHeader.insertBefore(root, insertTarget);
-      } else {
-          // Fallback
-          sidebarHeader.appendChild(root);
-      }
-      
-      render(h(FloatingEntry, null), root);
-    }
-  };
-
-  // Check immediately
+  ensureToasterMounted();
   mountFloatingEntry();
 
-  // Poll for sidebar header presence (it might load dynamically)
-  const intervalId = setInterval(() => {
-    if (document.querySelector('.cgptx-mini-wrap')) {
-      clearInterval(intervalId);
-      return;
-    }
+  if (sidebarObserver) return;
+  sidebarObserver = new MutationObserver(() => {
     mountFloatingEntry();
-  }, 1000);
+  });
+  sidebarObserver.observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+
+  if (sidebarPollTimer === null) {
+    sidebarPollTimer = window.setInterval(() => {
+      mountFloatingEntry();
+    }, 250);
+  }
 }

--- a/src/ui/components/ActionButtons.tsx
+++ b/src/ui/components/ActionButtons.tsx
@@ -150,7 +150,7 @@ export function ActionButtons({ autoSaveState }: ActionButtonsProps) {
             <button
                 id="cgptx-mini-btn-batch"
                 className="cgptx-mini-btn"
-                title="批量导出 JSON + 附件（可勾选）"
+                title="批量导出"
                 onClick={handleBatchExport}
             >
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/src/ui/components/ActionButtons.tsx
+++ b/src/ui/components/ActionButtons.tsx
@@ -151,6 +151,7 @@ export function ActionButtons({ autoSaveState }: ActionButtonsProps) {
                 id="cgptx-mini-btn-batch"
                 className="cgptx-mini-btn"
                 title="批量导出"
+                aria-label="批量导出"
                 onClick={handleBatchExport}
             >
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -163,6 +164,7 @@ export function ActionButtons({ autoSaveState }: ActionButtonsProps) {
                     id="cgptx-mini-btn-autosave"
                     className="cgptx-mini-btn"
                     title={tooltip}
+                    aria-label="自动保存设置"
                     onClick={handleAutoSaveClick}
                     style={btnStyle}
                 >

--- a/src/ui/components/DownloadFilesButton.tsx
+++ b/src/ui/components/DownloadFilesButton.tsx
@@ -15,7 +15,7 @@ interface DownloadFilesButtonProps {
 
 export function DownloadFilesButton({ refreshCredStatus, cachedData, onDataFetched }: DownloadFilesButtonProps) {
     const [busy, setBusy] = useState(false);
-    const [title, setTitle] = useState('下载当前对话中可识别的文件/指针');
+
 
     const handleFilesDownload = async () => {
         const id = convId();
@@ -26,7 +26,6 @@ export function DownloadFilesButton({ refreshCredStatus, cachedData, onDataFetch
         }
 
         setBusy(true);
-        setTitle('下载文件中…');
 
         try {
             await refreshCredStatus();
@@ -41,23 +40,19 @@ export function DownloadFilesButton({ refreshCredStatus, cachedData, onDataFetch
             const cands = collectFileCandidates(data);
             if (!cands.length) {
                 toast.info('未找到可下载的文件/指针。');
-                setTitle('未找到文件');
                 setBusy(false);
                 return;
             }
 
             showFilePreviewDialog(cands, async (selected) => {
                 setBusy(true);
-                setTitle(`下载中 (${selected.length})…`);
 
                 try {
                     const res = await downloadSelectedFiles(selected);
-                    setTitle(`完成 ${res.ok}/${res.total}（可再次点击）`);
                     toast.success(`文件下载完成，成功 ${res.ok}/${res.total}`);
                 } catch (e: any) {
                     console.error('[ChatGPT-Multimodal-Exporter] 下载失败：', e);
                     toast.error('下载失败: ' + (e && e.message ? e.message : e));
-                    setTitle('下载失败 ❌');
                 } finally {
                     setBusy(false);
                 }
@@ -67,7 +62,6 @@ export function DownloadFilesButton({ refreshCredStatus, cachedData, onDataFetch
         } catch (e: any) {
             console.error('[ChatGPT-Multimodal-Exporter] 下载失败：', e);
             toast.error('下载失败: ' + (e && e.message ? e.message : e));
-            setTitle('下载失败 ❌');
             setBusy(false);
         }
     };
@@ -76,7 +70,7 @@ export function DownloadFilesButton({ refreshCredStatus, cachedData, onDataFetch
         <button
             id="cgptx-mini-btn-files"
             className="cgptx-mini-btn"
-            title={title}
+            title={'下载当前对话的文件'}
             onClick={handleFilesDownload}
             disabled={busy}
         >

--- a/src/ui/components/DownloadFilesButton.tsx
+++ b/src/ui/components/DownloadFilesButton.tsx
@@ -71,6 +71,7 @@ export function DownloadFilesButton({ refreshCredStatus, cachedData, onDataFetch
             id="cgptx-mini-btn-files"
             className="cgptx-mini-btn"
             title={'下载当前对话的文件'}
+            aria-label="下载当前对话的文件"
             onClick={handleFilesDownload}
             disabled={busy}
         >

--- a/src/ui/components/ExportJsonButton.tsx
+++ b/src/ui/components/ExportJsonButton.tsx
@@ -11,7 +11,6 @@ interface ExportJsonButtonProps {
 
 export function ExportJsonButton({ refreshCredStatus, onDataFetched }: ExportJsonButtonProps) {
     const [busy, setBusy] = useState(false);
-    const [title, setTitle] = useState('导出当前对话 JSON');
 
     const handleJsonExport = async () => {
         const id = convId();
@@ -22,7 +21,6 @@ export function ExportJsonButton({ refreshCredStatus, onDataFetched }: ExportJso
         }
 
         setBusy(true);
-        setTitle('导出中…');
 
         try {
             await refreshCredStatus();
@@ -34,12 +32,10 @@ export function ExportJsonButton({ refreshCredStatus, onDataFetched }: ExportJso
             const safeTitle = sanitize(data?.title || '');
             const filename = `${safeTitle || 'chat'}_${id}.json`;
             saveJSON(data, filename);
-            setTitle('导出完成 ✅（点击可重新导出）');
             toast.success('导出 JSON 完成');
         } catch (e: any) {
             console.error('[ChatGPT-Multimodal-Exporter] 导出失败：', e);
             toast.error('导出失败: ' + (e && e.message ? e.message : e));
-            setTitle('导出失败 ❌（点击重试）');
         } finally {
             setBusy(false);
         }
@@ -49,7 +45,7 @@ export function ExportJsonButton({ refreshCredStatus, onDataFetched }: ExportJso
         <button
             id="cgptx-mini-btn"
             className="cgptx-mini-btn"
-            title={title}
+            title="导出 JSON"
             onClick={handleJsonExport}
             disabled={busy}
         >

--- a/src/ui/components/ExportJsonButton.tsx
+++ b/src/ui/components/ExportJsonButton.tsx
@@ -46,6 +46,7 @@ export function ExportJsonButton({ refreshCredStatus, onDataFetched }: ExportJso
             id="cgptx-mini-btn"
             className="cgptx-mini-btn"
             title="导出 JSON"
+            aria-label="导出 JSON"
             onClick={handleJsonExport}
             disabled={busy}
         >

--- a/src/ui/components/FloatingEntry.tsx
+++ b/src/ui/components/FloatingEntry.tsx
@@ -9,7 +9,11 @@ import { DownloadFilesButton } from './DownloadFilesButton';
 import { ActionButtons } from './ActionButtons';
 import { Conversation } from '../../types';
 
-export function FloatingEntry() {
+interface FloatingEntryProps {
+  collapsed?: boolean;
+}
+
+export function FloatingEntry({ collapsed = false }: FloatingEntryProps) {
   const { status, refreshCredStatus } = useCredentialStatus();
   // Use new hook
   const autoSaveState = useAutoSave();
@@ -53,20 +57,22 @@ export function FloatingEntry() {
   const isOk = status.hasToken && status.hasAcc;
 
   return (
-    <div className="cgptx-mini-wrap">
+    <div className={`cgptx-mini-wrap${collapsed ? ' cgptx-mini-wrap-collapsed' : ''}`}>
       <StatusPanel status={status} isOk={isOk} />
-      <div className="cgptx-mini-btn-row">
-        <ExportJsonButton
-          refreshCredStatus={refreshCredStatus}
-          onDataFetched={updateCache}
-        />
-        <DownloadFilesButton
-          refreshCredStatus={refreshCredStatus}
-          cachedData={lastConvData}
-          onDataFetched={updateCache}
-        />
-        <ActionButtons autoSaveState={autoSaveState} />
-      </div>
+      {!collapsed && (
+        <div className="cgptx-mini-btn-row">
+          <ExportJsonButton
+            refreshCredStatus={refreshCredStatus}
+            onDataFetched={updateCache}
+          />
+          <DownloadFilesButton
+            refreshCredStatus={refreshCredStatus}
+            cachedData={lastConvData}
+            onDataFetched={updateCache}
+          />
+          <ActionButtons autoSaveState={autoSaveState} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ui/components/FloatingEntry.tsx
+++ b/src/ui/components/FloatingEntry.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { getRootHandle, startAutoSaveLoop } from '../../autoSave';
 import { Cred } from '../../cred';
 import { useCredentialStatus } from '../hooks/useCredentialStatus';
@@ -14,11 +14,12 @@ export function FloatingEntry() {
   // Use new hook
   const autoSaveState = useAutoSave();
 
-  // Shared cache for conversation data to optimize fetches between buttons
-  const lastConvData = useRef<Conversation | null>(null);
+  // Shared cache for conversation data to optimize fetches between buttons.
+  // Use state so updates are reactive and sibling buttons receive fresh data.
+  const [lastConvData, setLastConvData] = useState<Conversation | null>(null);
 
   const updateCache = (data: Conversation) => {
-    lastConvData.current = data;
+    setLastConvData(data);
   };
 
   useEffect(() => {
@@ -61,7 +62,7 @@ export function FloatingEntry() {
         />
         <DownloadFilesButton
           refreshCredStatus={refreshCredStatus}
-          cachedData={lastConvData.current}
+          cachedData={lastConvData}
           onDataFetched={updateCache}
         />
         <ActionButtons autoSaveState={autoSaveState} />

--- a/src/ui/components/StatusPanel.tsx
+++ b/src/ui/components/StatusPanel.tsx
@@ -1,5 +1,3 @@
-import { useState, useEffect } from 'preact/hooks';
-import { Cred } from '../../cred';
 import { CredStatus } from '../hooks/useCredentialStatus';
 
 interface StatusPanelProps {
@@ -8,42 +6,15 @@ interface StatusPanelProps {
 }
 
 export function StatusPanel({ status, isOk }: StatusPanelProps) {
-	const [workspaceInfo, setWorkspaceInfo] = useState('Checking...');
-
-	useEffect(() => {
-		const updateWs = () => {
-			if (!status.hasAcc) {
-				setWorkspaceInfo('Checking...');
-				return;
-			}
-
-			const acc = Cred.accountId;
-			if (acc) {
-				const workspaceType = acc === 'personal' ? 'Personal' : 'Team'
-				setWorkspaceInfo('Workspace: ' + workspaceType);
-			}
-		};
-		updateWs();
-	}, [status.hasAcc]);
-
+	// Only show if there is an issue to minimize noise, or just a subtle indicator
+	const title = `Token: ${status.hasToken ? '✔' : '✖'} / Account: ${status.hasAcc ? '✔' : '✖'}${status.userLabel ? ` / User: ${status.userLabel}` : ''}`;
+	
 	return (
 		<div className="cgptx-mini-badges-col">
 			<div
 				className={`cgptx-mini-badge ${isOk ? 'ok' : 'bad'}`}
-				id="cgptx-mini-badge"
-				title={status.debug}
-			>
-				{`Token: ${status.hasToken ? '✔' : '✖'} / Account id: ${status.hasAcc ? '✔' : '✖'}`}
-			</div>
-			<div className="cgptx-mini-badge info" title="Current Workspace Context">
-				{workspaceInfo}
-			</div>
-			{status.userLabel && (
-				<div className="cgptx-mini-badge info" title="Current User" style={{ maxWidth: '150px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-					User: {status.userLabel}
-				</div>
-			)}
-
+				title={title}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary\n- make sidebar toolbar mount robust across expanded/collapsed modes\n- show only status indicator in collapsed mode and keep tools hidden\n- align toolbar buttons to consistent sizing and equal spacing between ChatGPT and collapse controls\n- prevent autosave loop from being interrupted by UI remounts unless interval actually changes\n\n## Validation\n- pnpm build\n- manual verify on chatgpt.com:\n  - collapsed mode shows status light only\n  - expanded mode restores tools\n  - button spacing is equalized\n  - autosave icon no longer re-enters refresh state when reopening sidebar\n